### PR TITLE
Update project slug to fix failing Github Action

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -22,7 +22,7 @@ const siteConfig = {
   url: 'https://legend.finos.org',
   baseUrl: '/',
   // For publishing to GitHub pages
-  projectName: 'alloy',
+  projectName: 'legend',
   organizationName: 'finos',
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [


### PR DESCRIPTION
```

Run # Extract GitHub org/user
Git repo - adamj-codethink/legend
Git user - adamj-codethink

> @ publish-gh-pages /home/runner/work/legend/legend/website
> docusaurus-publish

HEAD
https://github.com/adamj-codethink/legend
generate.js triggered...
[WARN] unresolved links in file 'getting-started/review-process.md' > [ 'roles.md' ]
sitemap.js triggered...
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
Site built successfully. Generated files in 'build' folder.
de54afff3e4b0cd277cbea0ecfbf16096ab70c6d
Cloning into 'alloy-gh-pages'...
remote: Repository not found.
fatal: repository 'https://github.com/adamj-codethink/alloy.git/' not found
Error: git clone failed
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ publish-gh-pages: `docusaurus-publish`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @ publish-gh-pages script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-10-20T13_45_57_180Z-debug.log
Error: Process completed with exit code 1.
```